### PR TITLE
[1.21.1] 修复打开设置界面时鼠标被重置的问题

### DIFF
--- a/src/main/java/studio/fantasyit/maid_storage_manager/maid/task/StorageManageTask.java
+++ b/src/main/java/studio/fantasyit/maid_storage_manager/maid/task/StorageManageTask.java
@@ -212,6 +212,11 @@ public class StorageManageTask implements IMaidTask, ICommunicatable {
             public AbstractContainerMenu createMenu(int index, Inventory playerInventory, Player player) {
                 return new StorageManagerMaidConfigGui.Container(index, playerInventory, maid.getId());
             }
+
+            @Override
+            public boolean shouldTriggerClientSideContainerClosingOnOpen() {
+                return false;
+            }
         };
     }
 
@@ -234,10 +239,5 @@ public class StorageManageTask implements IMaidTask, ICommunicatable {
         if (!data.doCommunicate())
             return null;
         return ICommunicatable.super.acceptCommunicateWish(handler, wish);
-    }
-
-    @Override
-    public boolean shouldTriggerClientSideContainerClosingOnOpen() {
-        return false;
     }
 }


### PR DESCRIPTION
`StorageManageTask#getTaskConfigGuiProvider` 的 `MenuProvider` 补充 `shouldTriggerClientSideContainerClosingOnOpen()`，
  返回 `false`，避免按钮点击时先 `setScreen(null)`，鼠标被 GLFW 重置的问题。