### PR TITLE
1.21 可配置交流终端UI bug修复

### DIFF
--- a/src/main/java/studio/fantasyit/maid_storage_manager/items/ConfigurableCommunicateTerminal.java
+++ b/src/main/java/studio/fantasyit/maid_storage_manager/items/ConfigurableCommunicateTerminal.java
@@ -141,10 +141,6 @@ public class ConfigurableCommunicateTerminal extends MaidInteractItem implements
     }
 
     public static void setWorkCardItem(ItemStack item, ItemStack workCard) {
-        if(workCard.isEmpty()) {
-            item.remove(DataComponentRegistry.COMMUNICATE_WORK_CARD);
-        } else {
-            item.set(DataComponentRegistry.COMMUNICATE_WORK_CARD, workCard);
-        }
+        item.set(DataComponentRegistry.COMMUNICATE_WORK_CARD, workCard);
     }
 }

--- a/src/main/java/studio/fantasyit/maid_storage_manager/registry/DataComponentRegistry.java
+++ b/src/main/java/studio/fantasyit/maid_storage_manager/registry/DataComponentRegistry.java
@@ -138,7 +138,7 @@ public class DataComponentRegistry {
     public static final DeferredHolder<DataComponentType<?>, DataComponentType<Boolean>> COMMUNICATE_MANUAL = DATA_COMPONENTS
             .register("communicate_manual", () -> DataComponentType.<Boolean>builder().persistent(Codec.BOOL).networkSynchronized(ByteBufCodecs.BOOL).build());
     public static final DeferredHolder<DataComponentType<?>, DataComponentType<ItemStack>> COMMUNICATE_WORK_CARD = DATA_COMPONENTS
-            .register("communicate_work_card", () -> DataComponentType.<ItemStack>builder().persistent(ItemStack.CODEC).networkSynchronized(ItemStack.STREAM_CODEC).build());
+            .register("communicate_work_card", () -> DataComponentType.<ItemStack>builder().persistent(ItemStack.OPTIONAL_CODEC).networkSynchronized(ItemStack.OPTIONAL_STREAM_CODEC).build());
     public static final DeferredHolder<DataComponentType<?>, DataComponentType<UUID>> COMMUNICATE_LAST_WORK_UUID = DATA_COMPONENTS
             .register("communicate_last_work_uuid", () -> DataComponentType.<UUID>builder().persistent(UUIDUtil.CODEC).networkSynchronized(UUIDUtil.STREAM_CODEC).build());
 


### PR DESCRIPTION
下述两个bug本人只在MC 1.21版本的mod上做了研究和修复，不清楚bug在别的分支是否也存在。

#### 修复了可配置交流终端UI在非自动模式下崩溃的bug

当前版本下，打开新合成的可配置交流终端的UI，并将工作模式从“自动识别”切换至任意其他模式，服务端会很快崩溃，原因是尝试将空的工牌格`ItemStack`保存进物品组件，而MC本体不允许序列化空`ItemStack`。

https://github.com/zxy19/maid_storage_manager/blob/99f800a/src/main/java/studio/fantasyit/maid_storage_manager/items/ConfigurableCommunicateTerminal.java#L144

~~本PR添加条件判断，当工牌为空时改为移除对应的物品组件。读取时会自动取空`ItemStack`为默认值故不需要更改。这个修复方案在本人看来不甚完美，但在MC本体的源码中也未找到更好的例子，故先如此修复。~~ 修复方案为将工牌格的数据组件改为`ItemStack.OPTIONAL_CODEC`编码。

#### 移除了可配置交流终端UI切换选项声音的无效字幕

当前版本下，可配置交流终端UI中用鼠标滚轮切换的选项发出的声音会带有未提供本地化字符串的字幕。鉴于MC本体的按钮点击等UI音效均无字幕，为保持一致性，移除了滚轮切换音效的字幕注册。