### PR TITLE
1.21.1 修复合成指南UI输入框空白时鼠标滚轮导致崩溃

### DIFF
--- a/src/main/java/studio/fantasyit/maid_storage_manager/craft/context/common/CommonIdleAction.java
+++ b/src/main/java/studio/fantasyit/maid_storage_manager/craft/context/common/CommonIdleAction.java
@@ -25,7 +25,7 @@ public class CommonIdleAction extends AbstractCraftActionContext {
                     ResourceLocation.fromNamespaceAndPath("maid_storage_manager", "textures/gui/craft/option/wait_second.png"),
                     ResourceLocation.fromNamespaceAndPath("maid_storage_manager", "textures/gui/craft/option/wait_tick.png")
             },
-            "",
+            "0",
             new ActionOption.BiConverter<>(
                     i -> i != 0, b -> b ? 1 : 0
             ),

--- a/src/main/java/studio/fantasyit/maid_storage_manager/menu/craft/common/CommonCraftScreen.java
+++ b/src/main/java/studio/fantasyit/maid_storage_manager/menu/craft/common/CommonCraftScreen.java
@@ -19,6 +19,7 @@ import net.minecraft.world.inventory.Slot;
 import net.minecraft.world.item.ItemStack;
 import net.neoforged.neoforge.network.PacketDistributor;
 import org.anti_ad.mc.ipn.api.IPNIgnore;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.mutable.MutableInt;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -498,11 +499,11 @@ public class CommonCraftScreen extends AbstractFilterScreen<CommonCraftMenu> imp
             return true;
         }
         Optional<GuiEventListener> child = this.getChildAt(x, y);
-        if (child.isPresent() && child.get() instanceof EditBox eb && eb.isVisible()) {
+        if (child.isPresent() && child.get() instanceof EditBox eb && eb.isVisible() && StringUtils.isNumeric(eb.getValue())) {
             int dv = (int) (Math.abs(p_94688_) / p_94688_);
             if (InputConstants.isKeyDown(Minecraft.getInstance().getWindow().getWindow(), InputConstants.KEY_LSHIFT))
                 dv *= 10;
-            Integer ov = Integer.valueOf(eb.getValue());
+            int ov = Integer.parseInt(eb.getValue());
             eb.setValue(String.valueOf(ov + dv));
             return true;
         }


### PR DESCRIPTION
下述bug本人只在MC 1.21.1版本的mod上做了研究和修复，不清楚bug在别的分支是否也存在。

合成指南的空闲任务有一个指定等待时长的输入框，当前版本下其默认值是空值。合成指南的UI代码允许鼠标指向一个输入框的时候用鼠标滚轮微调其数值，但计算时并未检查该输入框中的内容是否是数值（甚至是否有值），从而导致客户端崩溃。

https://github.com/zxy19/maid_storage_manager/blob/218bd35/src/main/java/studio/fantasyit/maid_storage_manager/menu/craft/common/CommonCraftScreen.java#L505

本PR的修复方案是限定鼠标滚轮微调逻辑只在输入框中已有数值时生效，同时为空闲任务的输入框指定默认值为0，使鼠标滚轮初始可用。

另一个修复方案是令微调逻辑将空值视为0，但没有选择这么改，因为以我目前对合成指南UI代码的理解，虽然目前的任务选项只有空闲任务用到输入框，但代码结构是允许输入框是为非数值的，只处理空值的情况可能为后续添加其他任务选项时挖坑。