### PR TITLE
1.20.1 修复可配置交流终端完成一次交流后cd重置不正确导致cd时间显著变长的问题

### DIFF
--- a/src/main/java/studio/fantasyit/maid_storage_manager/items/ConfigurableCommunicateTerminal.java
+++ b/src/main/java/studio/fantasyit/maid_storage_manager/items/ConfigurableCommunicateTerminal.java
@@ -60,6 +60,7 @@ public class ConfigurableCommunicateTerminal extends MaidInteractItem implements
                 Pair<UUID, Boolean> lastResult = CommunicateUtil.getLastResult(maid);
                 if (lastResult.getA().equals(tag.getUUID("last_task")) && lastResult.getB()) {
                     tag.putInt("cd", Config.communicateCDFinish);
+                    cd = Config.communicateCDFinish;
                 }
                 CommunicateUtil.clearLastResult(maid);
             }


### PR DESCRIPTION
由于没有把cd变量一并重置，下文`tag.putInt("cd", cd - 1);`会直接覆盖掉结果，直接表现就是用很长的fail cd覆盖掉了本应该很短的finish cd，进一步导致可配置交流终端交流cd变长。