### PR TITLE
fix: add ammo NBT wildcard matching for TACZ gun recipe ingredients

### DIFF
--- a/src/main/java/studio/fantasyit/maid_storage_manager/integration/tacz/TaczRecipe.java
+++ b/src/main/java/studio/fantasyit/maid_storage_manager/integration/tacz/TaczRecipe.java
@@ -12,6 +12,7 @@ import com.tacz.guns.resource.filter.RecipeFilter;
 import com.tacz.guns.resource.index.CommonBlockIndex;
 import com.tacz.guns.resource.pojo.data.block.TabConfig;
 import net.minecraft.core.BlockPos;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.crafting.RecipeManager;
 import net.minecraft.world.level.Level;
@@ -45,6 +46,17 @@ public class TaczRecipe {
                 return gun.getGunId(stack).equals(gun.getGunId(target));
             }
             return false;
+        });
+        // 弹药通配符匹配: 第三方枪包配方中 "tacz:ammo" 作为原料时不指定 AmmoId,
+        // GunSmithTableIngredient 构建的 ItemStack 无 NBT, 而库存弹药带 {AmmoId:"xxx"},
+        // 严格 NBT 比较会失败。此处当任一方无 AmmoId 时视为通配符匹配。
+        event.addItemStackPredicate(ModItems.AMMO.get(), (stack, target) -> {
+            CompoundTag sTag = stack.getTag();
+            CompoundTag tTag = target.getTag();
+            String sAmmo = sTag != null ? sTag.getString("AmmoId") : "";
+            String tAmmo = tTag != null ? tTag.getString("AmmoId") : "";
+            if (sAmmo.isEmpty() || tAmmo.isEmpty()) return true;
+            return sAmmo.equals(tAmmo);
         });
     }
 


### PR DESCRIPTION
问题: 第三方 TACZ 枪包配方中 tacz:ammo 作为原料时不指定 AmmoId NBT（通配符），但 MSM 对 tacz:ammo（在 use_nbt 标签中）做严格 NBT 比较，导致库存中带 {AmmoId:"xxx"} 的弹药无法匹配配方原料。
改动: [TaczRecipe.java](https://github.com/GongShun-123/maid_storage_manager/blob/fix/tacz-ammo-wildcard-nbt-matching/src/main/java/studio/fantasyit/maid_storage_manager/integration/tacz/TaczRecipe.java) — 1 文件，+11 行（1 import + 10 行 predicate）；
修复: 在已有的枪械 predicate 旁新增弹药 predicate——当任一方无 AmmoId 时视为通配符匹配，双方都有时精确比较。
event.addItemStackPredicate(ModItems.AMMO.get(), (stack, target) -> {
    CompoundTag sTag = stack.getTag();
    CompoundTag tTag = target.getTag();
    String sAmmo = sTag != null ? sTag.getString("AmmoId") : "";
    String tAmmo = tTag != null ? tTag.getString("AmmoId") : "";
    if (sAmmo.isEmpty() || tAmmo.isEmpty()) return true;
    return sAmmo.equals(tAmmo);
});
